### PR TITLE
Import contacts

### DIFF
--- a/app/src/androidTest/java/ch/epfl/reminday/testutils/IdlingResources.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/testutils/IdlingResources.kt
@@ -5,11 +5,14 @@ import androidx.test.espresso.IdlingResource
 
 object IdlingResources {
 
+    private val myIdlingResources: ArrayList<IdlingResource> = arrayListOf()
+
     /**
      * Registers the given [IdlingResource]
      * @param resources [IdlingResources] to register into the instantiated [IdlingRegistry]
      */
     fun register(vararg resources: IdlingResource) {
+        myIdlingResources.addAll(resources)
         IdlingRegistry.getInstance().register(*resources)
     }
 
@@ -20,8 +23,9 @@ object IdlingResources {
      */
     fun unregisterAll() {
         val registry = IdlingRegistry.getInstance()
-        registry.resources.forEach { res ->
+        myIdlingResources.forEach { res ->
             registry.unregister(res)
         }
+        myIdlingResources.clear()
     }
 }

--- a/app/src/androidTest/java/ch/epfl/reminday/testutils/NumberPickerTestUtils.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/testutils/NumberPickerTestUtils.kt
@@ -88,18 +88,23 @@ object NumberPickerTestUtils {
 
             val picker = checkPreconditions(view, value, description)
 
-            if (picker.value != value) {
-                picker.value = value
-
-                // trigger onValueChange callback by manually changing and restoring the value
-                if (picker.minValue != value) {
-                    mDecrement.perform(uiController, view)
+            // trigger onValueChange callback by manually changing and restoring the value
+            when {
+                !(picker.minValue <= value && value <= picker.maxValue) ->
+                    throw IllegalArgumentException("Invalid value (not ${picker.minValue} <= $value <= ${picker.maxValue})")
+                picker.minValue < value -> {
+                    picker.value = value - 1
                     mIncrement.perform(uiController, view)
-                } else if (picker.maxValue != value) {
-                    mIncrement.perform(uiController, view)
+                }
+                value < picker.maxValue -> {
+                    picker.value = value + 1
                     mDecrement.perform(uiController, view)
                 }
+                else -> { // min == value == max
+                    picker.value = value
+                }
             }
+            uiController?.loopMainThreadUntilIdle()
         }
     }
 

--- a/app/src/androidTest/java/ch/epfl/reminday/ui/activity/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/ui/activity/MainActivityInstrumentedTest.kt
@@ -1,5 +1,11 @@
 package ch.epfl.reminday.ui.activity
 
+import android.Manifest.permission.READ_CONTACTS
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.provider.ContactsContract.CommonDataKinds.Event.START_DATE
+import android.provider.ContactsContract.Contacts.DISPLAY_NAME_PRIMARY
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -9,21 +15,37 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.rule.GrantPermissionRule
 import ch.epfl.reminday.R
 import ch.epfl.reminday.data.birthday.BirthdayDao
+import ch.epfl.reminday.data.contacts.ContactQuery
+import ch.epfl.reminday.data.contacts.ContactQueryDI
+import ch.epfl.reminday.testutils.IdlingResources
+import ch.epfl.reminday.testutils.MockitoMatchers.any
+import ch.epfl.reminday.testutils.MockitoMatchers.anyNullable
 import ch.epfl.reminday.testutils.UITestUtils
 import ch.epfl.reminday.util.Mocks
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL
+import ch.epfl.reminday.viewmodel.activity.MainViewModel
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import io.github.serpro69.kfaker.Faker
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.allOf
 import org.junit.After
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.*
+import java.time.LocalDate
 import javax.inject.Inject
+import org.mockito.Mockito.`when` as whenever
 
+@UninstallModules(ContactQueryDI::class)
 @HiltAndroidTest
 class MainActivityInstrumentedTest {
 
@@ -33,23 +55,52 @@ class MainActivityInstrumentedTest {
     @get:Rule(order = 1)
     val scenarioRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @get:Rule(order = 2)
+    val permissionRule = GrantPermissionRule.grant(READ_CONTACTS)!!
+
+
     @Inject
     lateinit var dao: BirthdayDao
 
+    @BindValue
+    @JvmField
+    val contactQuery: ContactQuery = mock(ContactQuery::class.java)
+    private lateinit var cursor: Cursor
+
+    private lateinit var faker: Faker
+
     @Before
-    fun init() {
+    fun init(): Unit = runBlocking {
+        reset(contactQuery)
+        cursor = mock(Cursor::class.java)
+
+        whenever(
+            contactQuery.query(
+                any(),
+                any(),
+                any(),
+                any(),
+                anyNullable(),
+                anyNullable(),
+            )
+        ).thenReturn(cursor)
+
         Intents.init()
         hiltRule.inject()
+
+        faker = Mocks.makeFaker()
     }
 
     @After
     fun clear() {
         Intents.release()
+        IdlingResources.unregisterAll()
     }
 
     @Test
     fun addBirthdayButtonLaunchesAddBirthdayActivity() {
-        UITestUtils.onMenuItem(withText(R.string.add_birthday_item_text)).perform(click())
+        UITestUtils.onMenuItem(withText(R.string.add_birthday_item_text))
+            .perform(click())
 
         intended(
             allOf(
@@ -65,6 +116,95 @@ class MainActivityInstrumentedTest {
 
         onView(withId(R.id.birthday_list_recycler))
             .perform(UITestUtils.waitUntilPopulated())
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun importFromContactsInsertsThemIntoDao(): Unit = runBlocking {
+        scenarioRule.scenario.onActivity {
+            IdlingResources.register(it.importIdlingResource)
+        }
+
+        // initialize mock Cursor
+        whenever(cursor.getColumnIndex(any())).then {
+            when (it.getArgument<String>(0)) {
+                DISPLAY_NAME_PRIMARY -> 0
+                START_DATE -> 1
+                else -> -1
+            }
+        }
+        // exactly 3 contacts provided
+        whenever(cursor.moveToNext()).thenReturn(true, true, true, false)
+
+        val bDays = Mocks.birthdays(3, yearKnown = { it == 0 })
+        val names = bDays.map { it.personName }
+        val dates = bDays.map {
+            if (it.isYearKnown) LocalDate.of(it.year!!.value, it.monthDay.month, it.monthDay.dayOfMonth).toString()
+            else it.monthDay.toString()
+        }
+        whenever(cursor.getString(0)).thenReturn(names[0], names[1], names[2]).thenThrow()
+        whenever(cursor.getString(1)).thenReturn(dates[0], dates[1], dates[2]).thenThrow()
+
+        UITestUtils.onMenuItem(withText(R.string.import_from_contacts_item_text))
+            .perform(click())
+
+        onView(withText(R.string.confirm)).perform(click())
+
+        Espresso.onIdle()
+
+        verify(cursor, times(2)).getColumnIndex(any())
+        verify(cursor, times(4)).moveToNext()
+        verify(cursor, times(6)).getString(anyInt())
+        verifyNoMoreInteractions(cursor)
+
+        val actualBDays = dao.getAll()
+        assertThat(actualBDays.size, `is`(3))
+        bDays.zip(actualBDays).forEach { pair ->
+            assertThat(pair.second, `is`(pair.first))
+        }
+    }
+
+    @Test
+    fun cancellingDoesNotInfluenceDAO(): Unit = runBlocking {
+        scenarioRule.scenario.onActivity {
+            IdlingResources.register(it.importIdlingResource)
+        }
+
+        // initialize mock Cursor
+        whenever(cursor.getColumnIndex(any())).then {
+            when (it.getArgument<String>(0)) {
+                DISPLAY_NAME_PRIMARY -> 0
+                START_DATE -> 1
+                else -> -1
+            }
+        }
+        whenever(cursor.moveToNext()).thenReturn(false)
+
+        UITestUtils.onMenuItem(withText(R.string.import_from_contacts_item_text))
+            .perform(click())
+
+        onView(withText(R.string.cancel)).perform(click())
+
+        // there should be no interactions at all
+        verifyNoInteractions(cursor)
+        assertTrue(dao.getAll().isEmpty())
+    }
+
+    @Test
+    fun triesAgainToImportWhenPermissionIsGranted() {
+        scenarioRule.scenario.onActivity {
+            IdlingResources.register(it.importIdlingResource)
+        }
+
+        scenarioRule.scenario.onActivity {
+            val code = MainViewModel.READ_CONTACTS_PERMISSION_CODE
+            val permissions = arrayOf(READ_CONTACTS)
+            val grantResults = intArrayOf(PackageManager.PERMISSION_GRANTED)
+            it.onRequestPermissionsResult(code, permissions, grantResults)
+        }
+
+        // assert that we're showing the confirmation dialog
+        onView(withText(R.string.import_from_contacts_are_you_sure))
             .check(matches(isDisplayed()))
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ch.epfl.reminday">
 
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="false"

--- a/app/src/main/java/ch/epfl/reminday/data/birthday/BirthdayDao.kt
+++ b/app/src/main/java/ch/epfl/reminday/data/birthday/BirthdayDao.kt
@@ -12,26 +12,46 @@ import java.time.Year
 @Dao
 interface BirthdayDao {
 
+    companion object {
+        private const val allUnordered =
+            "SELECT * FROM birthday"
+
+        private const val allByMonthDayYear =
+            "SELECT * FROM birthday ORDER BY monthDay, year"
+
+        private const val allByMonthDayYearFromToday =
+            "SELECT *, 1 as rowOrder FROM birthday WHERE monthDay >= :today " +
+                    "UNION ALL SELECT *, 2 as rowOrder FROM birthday WHERE monthDay < :today " +
+                    "ORDER BY rowOrder, monthDay, year"
+    }
+
     /**
      * Returns a paging source with all birthdays, ordered by primary key (ie. [Birthday.personName])
      * @return [PagingSource] with all birthdays
      */
-    @Query("SELECT * FROM birthday")
+    @Query(allUnordered)
     fun pagingSource(): PagingSource<Int, Birthday>
+
+    @Query(allUnordered)
+    suspend fun getAll(): List<Birthday>
+
 
     /**
      * Returns a paging source with all birthdays, ordered by (month, year, name)
      * @return [PagingSource] with all birthdays
      */
-    @Query("SELECT * FROM birthday ORDER BY monthDay, year")
+    @Query(allByMonthDayYear)
     fun pagingSourceOrderedByMonthDayYear(): PagingSource<Int, Birthday>
 
-
-    @Query("SELECT * FROM birthday")
-    suspend fun getAll(): List<Birthday>
-
-    @Query("SELECT * FROM birthday ORDER BY monthDay, year")
+    @Query(allByMonthDayYear)
     suspend fun getAllOrderedByMonthDayYear(): List<Birthday>
+
+
+    @Query(allByMonthDayYearFromToday)
+    fun pagingSourceOrderedByMonthDayYearFrom(today: MonthDay): PagingSource<Int, Birthday>
+
+    @Query(allByMonthDayYearFromToday)
+    suspend fun getAllOrderedByMonthDayYearFrom(today: MonthDay): List<Birthday>
 
 
     @Query("SELECT * FROM birthday WHERE personName LIKE :personName")

--- a/app/src/main/java/ch/epfl/reminday/data/contacts/ContactQuery.kt
+++ b/app/src/main/java/ch/epfl/reminday/data/contacts/ContactQuery.kt
@@ -1,0 +1,38 @@
+package ch.epfl.reminday.data.contacts
+
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import androidx.core.content.ContentResolverCompat
+import androidx.core.os.CancellationSignal
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Wrapper to perform queries on contacts via ContentResolverCompat ;
+ * can be mocked for tests.
+ */
+open class ContactQuery(
+    appContext: Context
+) {
+    private val contentResolver = appContext.contentResolver
+
+    open suspend fun query(
+        uri: Uri,
+        projection: Array<out String>,
+        selection: String,
+        selectionArgs: Array<out String>,
+        order: String?,
+        cancellationSignal: CancellationSignal?
+    ): Cursor? = withContext(Dispatchers.IO) {
+        ContentResolverCompat.query(
+            contentResolver,
+            uri,
+            projection,
+            selection,
+            selectionArgs,
+            order,
+            cancellationSignal
+        )
+    }
+}

--- a/app/src/main/java/ch/epfl/reminday/data/contacts/ContactQueryDI.kt
+++ b/app/src/main/java/ch/epfl/reminday/data/contacts/ContactQueryDI.kt
@@ -1,0 +1,19 @@
+package ch.epfl.reminday.data.contacts
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ContactQueryDI {
+
+    @Provides
+    @Singleton
+    fun provideContactQuery(@ApplicationContext context: Context): ContactQuery =
+        ContactQuery(context)
+}

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/BirthdayEditActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/BirthdayEditActivity.kt
@@ -1,7 +1,6 @@
 package ch.epfl.reminday.ui.activity
 
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
 import ch.epfl.reminday.R
@@ -10,6 +9,7 @@ import ch.epfl.reminday.data.birthday.BirthdayDao
 import ch.epfl.reminday.databinding.ActivityBirthdayEditBinding
 import ch.epfl.reminday.ui.activity.utils.BackArrowActivity
 import ch.epfl.reminday.util.Extensions.set
+import ch.epfl.reminday.util.Extensions.showConfirmationDialog
 import ch.epfl.reminday.util.constant.ArgumentNames
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -120,17 +120,11 @@ class BirthdayEditActivity : BackArrowActivity() {
         }
     }
 
-    private fun showConfirmOverwriteDialog(onConfirm: () -> Unit) {
-        AlertDialog.Builder(this)
-            .setTitle(R.string.are_you_sure)
-            .setMessage(R.string.birthday_will_be_overwritten)
-            .setPositiveButton(R.string.confirm) { dialog, _ ->
-                dialog.dismiss()
-                onConfirm.invoke()
-            }.setNegativeButton(R.string.cancel) { dialog, _ ->
-                dialog.cancel()
-            }.show()
-    }
+    private fun showConfirmOverwriteDialog(onConfirm: () -> Unit) = showConfirmationDialog(
+        title = R.string.are_you_sure,
+        text = R.string.birthday_will_be_overwritten,
+        onConfirm = onConfirm
+    )
 
     private suspend fun insertBirthdayAndFinish(birthday: Birthday) {
         dao.insertAll(birthday)

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/MainActivity.kt
@@ -1,15 +1,21 @@
 package ch.epfl.reminday.ui.activity
 
 import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import ch.epfl.reminday.R
 import ch.epfl.reminday.data.birthday.BirthdayDao
 import ch.epfl.reminday.databinding.ActivityMainBinding
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL
+import ch.epfl.reminday.viewmodel.activity.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -18,6 +24,7 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var dao: BirthdayDao
 
+    private val viewModel: MainViewModel by viewModels()
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,6 +44,10 @@ class MainActivity : AppCompatActivity() {
                 launchAddBirthdayActivity()
                 true
             }
+            R.id.import_from_contacts_item -> {
+                importBirthdaysFromContacts()
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }
@@ -45,5 +56,32 @@ class MainActivity : AppCompatActivity() {
         val intent = Intent(this, BirthdayEditActivity::class.java)
         intent.putExtra(BIRTHDAY_EDIT_MODE_ORDINAL, BirthdayEditActivity.Mode.ADD.ordinal)
         startActivity(intent)
+    }
+
+    private fun importBirthdaysFromContacts() {
+        if (viewModel.mayRequireContacts(this)) {
+            lifecycleScope.launch {
+                val contacts = viewModel.importContacts(this@MainActivity)
+                contacts.forEach { Log.d(this@MainActivity.javaClass.name, it.toString()) }
+                dao.insertAll(*contacts.toTypedArray())
+            }
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        when (requestCode) {
+            MainViewModel.READ_CONTACTS_PERMISSION_CODE -> {
+                // try again to import if permission was granted
+                if (grantResults.all { it == PERMISSION_GRANTED }) {
+                    importBirthdaysFromContacts()
+                }
+            }
+            else ->
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        }
     }
 }

--- a/app/src/main/java/ch/epfl/reminday/util/Extensions.kt
+++ b/app/src/main/java/ch/epfl/reminday/util/Extensions.kt
@@ -1,6 +1,10 @@
 package ch.epfl.reminday.util
 
 import android.text.Editable
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import ch.epfl.reminday.R
 
 /**
  * Extension functions for various classes.
@@ -13,5 +17,28 @@ object Extensions {
      */
     fun Editable.set(string: String?) {
         replace(0, length, string ?: "")
+    }
+
+    /**
+     * Shows a default confirmation dialog with a custom title and message,
+     * and "confirm" and "cancel" buttons.
+     * @param title Int, R.string of the title to print
+     * @param text Int, R.string of the message to print
+     * @param onConfirm will be run only if the user presses "confirm".
+     */
+    fun AppCompatActivity.showConfirmationDialog(
+        @StringRes title: Int,
+        @StringRes text: Int,
+        onConfirm: () -> Unit
+    ) {
+        AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(text)
+            .setPositiveButton(R.string.confirm) { dialog, _ ->
+                dialog.dismiss()
+                onConfirm.invoke()
+            }.setNegativeButton(R.string.cancel) { dialog, _ ->
+                dialog.cancel()
+            }.show()
     }
 }

--- a/app/src/main/java/ch/epfl/reminday/viewmodel/activity/MainViewModel.kt
+++ b/app/src/main/java/ch/epfl/reminday/viewmodel/activity/MainViewModel.kt
@@ -1,0 +1,106 @@
+package ch.epfl.reminday.viewmodel.activity
+
+import android.Manifest.permission.READ_CONTACTS
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.os.Build
+import android.provider.ContactsContract
+import android.provider.ContactsContract.CommonDataKinds.Event.*
+import android.provider.ContactsContract.Contacts.DISPLAY_NAME_PRIMARY
+import android.provider.ContactsContract.Data.MIMETYPE
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContentResolverCompat
+import androidx.core.content.ContextCompat.checkSelfPermission
+import androidx.lifecycle.ViewModel
+import ch.epfl.reminday.data.birthday.Birthday
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.DateTimeException
+import java.time.LocalDate
+import java.time.MonthDay
+import java.time.Year
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+) : ViewModel() {
+    companion object {
+        const val READ_CONTACTS_PERMISSION_CODE = 0x100
+
+        val birthdayFormats = arrayOf(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            DateTimeFormatter.ofPattern("--MM-dd"),
+        )
+    }
+
+    fun mayRequireContacts(activity: AppCompatActivity): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        if (checkSelfPermission(activity, READ_CONTACTS) == PERMISSION_GRANTED) return true
+
+        if (activity.shouldShowRequestPermissionRationale(READ_CONTACTS)) {
+            println("Rationale")
+        }
+        activity.requestPermissions(arrayOf(READ_CONTACTS), READ_CONTACTS_PERMISSION_CODE)
+        return false
+    }
+
+    suspend fun importContacts(context: Context): List<Birthday> {
+        val uri = ContactsContract.Data.CONTENT_URI
+
+        val projection: Array<out String> = arrayOf(
+            DISPLAY_NAME_PRIMARY,
+            CONTACT_ID,
+            START_DATE,
+        )
+
+        val where = "$MIMETYPE = ? AND " +
+                "$TYPE = $TYPE_BIRTHDAY"
+        val selectionArgs: Array<out String> = arrayOf(
+            CONTENT_ITEM_TYPE
+        )
+
+        val cursor = withContext(Dispatchers.IO) {
+            ContentResolverCompat.query(
+                context.contentResolver,
+                uri,
+                projection,
+                where,
+                selectionArgs,
+                null,
+                null
+            )
+        }
+
+        val contacts = arrayListOf<Birthday>()
+        cursor?.let {
+            val nameColumn =
+                cursor.getColumnIndex(DISPLAY_NAME_PRIMARY)
+            val bDayColumn =
+                cursor.getColumnIndex(START_DATE)
+
+            while (cursor.moveToNext()) {
+                val name = cursor.getString(nameColumn)
+                val dayString = cursor.getString(bDayColumn)
+
+                val toAdd: Birthday = try {
+                    val yearMonthDay = LocalDate.parse(dayString)
+                    Birthday(
+                        personName = name,
+                        monthDay = MonthDay.of(yearMonthDay.month, yearMonthDay.dayOfMonth),
+                        year = Year.of(yearMonthDay.year),
+                    )
+                } catch (e: DateTimeException) {
+                    Birthday(
+                        personName = name,
+                        monthDay = MonthDay.parse(dayString),
+                    )
+                }
+
+                contacts.add(toAdd)
+            }
+        }
+        return contacts
+    }
+}

--- a/app/src/main/java/ch/epfl/reminday/viewmodel/fragment/BirthdayListViewModel.kt
+++ b/app/src/main/java/ch/epfl/reminday/viewmodel/fragment/BirthdayListViewModel.kt
@@ -7,6 +7,8 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import ch.epfl.reminday.data.birthday.BirthdayDao
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import java.time.MonthDay
 import javax.inject.Inject
 
 @HiltViewModel
@@ -14,8 +16,9 @@ class BirthdayListViewModel @Inject constructor(
     birthdayDao: BirthdayDao
 ) : ViewModel() {
 
-    private val pager = Pager(PagingConfig(pageSize = 20)) {
-        birthdayDao.pagingSourceOrderedByMonthDayYear()
+    // there's typically ~10 items on screen
+    private val pager = Pager(PagingConfig(pageSize = 40, prefetchDistance = 40)) {
+        birthdayDao.pagingSourceOrderedByMonthDayYearFrom(MonthDay.from(LocalDate.now()))
     }
 
     val flow = pager.flow.cachedIn(viewModelScope)

--- a/app/src/main/res/menu/menu_main_activity.xml
+++ b/app/src/main/res/menu/menu_main_activity.xml
@@ -4,4 +4,8 @@
     <item
         android:id="@+id/add_birthday_item"
         android:title="@string/add_birthday_item_text" />
+
+    <item
+        android:id="@+id/import_from_contacts_item"
+        android:title="@string/import_from_contacts_item_text" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
 
     <!-- Menu items -->
     <string name="add_birthday_item_text">Add birthday</string>
+    <string name="import_from_contacts_item_text">Import from contacts</string>
     <string name="edit_birthday_item_text">Edit birthday</string>
 
     <!-- Add/Edit birthday screen -->
@@ -29,6 +30,7 @@
     <string name="additional_info">Additional information</string>
 
     <string name="are_you_sure">Are you sure?</string>
+    <string name="import_from_contacts_are_you_sure">Are you sure you want to import from contacts ? Any existing birthday with a name conflict will be overwritten.</string>
     <string name="birthday_will_be_overwritten">A birthday for a person with the same name already exists. Are you sure you want to overwrite that entry?</string>
-    <string name="import_from_contacts_item_text">Import from contacts</string>
+    <string name="import_from_contacts_no_contacts">Found no contacts to import</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
 
     <string name="are_you_sure">Are you sure?</string>
     <string name="birthday_will_be_overwritten">A birthday for a person with the same name already exists. Are you sure you want to overwrite that entry?</string>
+    <string name="import_from_contacts_item_text">Import from contacts</string>
 </resources>

--- a/app/src/test/java/ch/epfl/reminday/data/contacts/ContactQueryTest.kt
+++ b/app/src/test/java/ch/epfl/reminday/data/contacts/ContactQueryTest.kt
@@ -1,0 +1,60 @@
+package ch.epfl.reminday.data.contacts
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.ContactsContract.CommonDataKinds.Event.CONTACT_ID
+import android.provider.ContactsContract.CommonDataKinds.Event.START_DATE
+import android.provider.ContactsContract.Contacts.DISPLAY_NAME_PRIMARY
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class ContactQueryTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockContentResolver: ContentResolver
+    private lateinit var mockCursor: Cursor
+
+    private lateinit var query: ContactQuery
+
+    @Before
+    fun init() {
+        mockContext = mockk()
+        mockContentResolver = mockk()
+        mockCursor = mockk()
+
+        every { mockContext.applicationContext } returns mockContext
+        every { mockContext.contentResolver } returns mockContentResolver
+
+        every {
+            mockContentResolver.query(any(), any(), any(), any(), any())
+        } returns mockCursor
+        every {
+            mockContentResolver.query(any(), any(), any(), any(), any(), any())
+        } returns mockCursor
+
+        query = ContactQuery(mockContext)
+    }
+
+    @Test
+    fun queryCallsContentResolverQuery(): Unit = runBlocking {
+        val uri: Uri = mockk()
+        val projection = arrayOf(
+            DISPLAY_NAME_PRIMARY,
+            CONTACT_ID,
+            START_DATE
+        )
+        val selection = "$DISPLAY_NAME_PRIMARY LIKE ?"
+        val selectionArgs = arrayOf("Toufi")
+
+        // Warning: SDK_INT isn't defined ->
+        // ContentResolverCompat calls the variant without cancellationSignal,
+        // and throws if cancellationSignal != null (because it can't be cancelled in SDKs < 16)
+        val cursor = query.query(uri, projection, selection, selectionArgs, null, null)
+        assertEquals(mockCursor, cursor)
+    }
+}


### PR DESCRIPTION
Adds the possibility to directly import your (SMS) contacts' birthdays.
Use the menu item in MainActivity. If the permission to read the contacts is not granted, it will ask for it ; then a confirmation dialog appears, to explain that the birthdays which names overlap with one of your contact will be overwritten.

ContactQuery is a wrapper around ContentResolverCompat, which is static hence not mockable on android.

Tested successfully on my samsung s10 ; on the emulator I didn't manage to create a contact with a birthday date.

<p align="left">
<img src="https://user-images.githubusercontent.com/13187080/164531307-4eb4b84c-7ffa-46d5-abe8-aacd114afeea.png"
width="300" alt="Import menu item in MainActivity" />
<img src="https://user-images.githubusercontent.com/13187080/164531434-6a0ec81c-19ef-4f34-9177-841fcdc65e5d.png" width="300" alt="Import confirmation dialog" />
</p>