### PR TITLE
Option screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,9 @@ dependencies {
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$hilt_version"
 
+    // Preferences (Compat)
+    implementation "androidx.preference:preference-ktx:1.2.0"
+
     // Faker (fake data generation)
     implementation 'io.github.serpro69:kotlin-faker:1.11.0'
 

--- a/app/src/androidTest/java/ch/epfl/reminday/security/DatabaseKeyManagerImplTest.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/security/DatabaseKeyManagerImplTest.kt
@@ -66,8 +66,8 @@ class DatabaseKeyManagerImplTest {
     }
 
     @Test
-    fun loadKeyReturnsNullIfNoKeyStored() {
-        assertNull(keyMgr.loadDatabaseKey())
+    fun loadKeyGeneratesNewKeyIfNoKeyStoredYet() {
+        assertNotNull(keyMgr.loadDatabaseKey())
     }
 
     @Test

--- a/app/src/androidTest/java/ch/epfl/reminday/ui/activity/BirthdaySummaryActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/ui/activity/BirthdaySummaryActivityInstrumentedTest.kt
@@ -30,7 +30,6 @@ import ch.epfl.reminday.util.Mocks
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL
 import ch.epfl.reminday.util.constant.PreferenceNames.GENERAL_PREFERENCES
-import ch.epfl.reminday.util.constant.PreferenceNames.GeneralPreferenceNames.SKIP_DELETE_CONFIRMATION
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
@@ -58,6 +57,7 @@ class BirthdaySummaryActivityInstrumentedTest {
     @Inject
     lateinit var infoDao: AdditionalInformationDao
 
+    private lateinit var context: Context
     private lateinit var preferences: SharedPreferences
 
     @Before
@@ -65,19 +65,15 @@ class BirthdaySummaryActivityInstrumentedTest {
         Intents.init()
         hiltRule.inject()
 
-        val context = getApplicationContext<Context>()
+        context = getApplicationContext()
         preferences = context.getSharedPreferences(GENERAL_PREFERENCES, Context.MODE_PRIVATE)
-        preferences.edit()
-            .remove(SKIP_DELETE_CONFIRMATION)
-            .commit()
+        preferences.edit().clear().commit()
     }
 
     @After
     fun release() {
         Intents.release()
-        preferences.edit()
-            .remove(SKIP_DELETE_CONFIRMATION)
-            .commit()
+        preferences.edit().clear().commit()
 
         IdlingResources.unregisterAll()
     }
@@ -126,7 +122,7 @@ class BirthdaySummaryActivityInstrumentedTest {
     @Test
     fun deleteActionDoesDeleteBirthdayFromDaoAndCloseActivity(): Unit = runBlocking {
         preferences.edit()
-            .putBoolean(SKIP_DELETE_CONFIRMATION, true)
+            .putBoolean(context.getString(R.string.prefs_show_delete_confirmation), false)
             .commit()
 
         BirthdayDatabaseTestDI.fillIn(birthdayDao)

--- a/app/src/androidTest/java/ch/epfl/reminday/ui/activity/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/ui/activity/MainActivityInstrumentedTest.kt
@@ -26,6 +26,9 @@ import ch.epfl.reminday.testutils.MockitoMatchers.anyNullable
 import ch.epfl.reminday.testutils.UITestUtils
 import ch.epfl.reminday.util.Mocks
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL
+import ch.epfl.reminday.util.constant.ArgumentNames.PREFERENCES_ID
+import ch.epfl.reminday.util.constant.PreferenceNames
+import ch.epfl.reminday.util.constant.PreferenceNames.GENERAL_PREFERENCES
 import ch.epfl.reminday.viewmodel.activity.MainViewModel
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -111,6 +114,19 @@ class MainActivityInstrumentedTest {
     }
 
     @Test
+    fun optionsButtonLaunchesPreferencesActivity() {
+        UITestUtils.onMenuItem(withText(R.string.options_text))
+            .perform(click())
+
+        intended(
+            allOf(
+                hasComponent(PreferencesActivity::class.java.name),
+                hasExtra(PREFERENCES_ID, GENERAL_PREFERENCES),
+            )
+        )
+    }
+
+    @Test
     fun birthdayListIsDisplayed(): Unit = runBlocking {
         dao.insertAll(Mocks.birthday(yearKnown = false))
 
@@ -139,7 +155,8 @@ class MainActivityInstrumentedTest {
         val bDays = Mocks.birthdays(3, yearKnown = { it == 0 })
         val names = bDays.map { it.personName }
         val dates = bDays.map {
-            if (it.isYearKnown) LocalDate.of(it.year!!.value, it.monthDay.month, it.monthDay.dayOfMonth).toString()
+            if (it.isYearKnown)
+                LocalDate.of(it.year!!.value, it.monthDay.month, it.monthDay.dayOfMonth).toString()
             else it.monthDay.toString()
         }
         whenever(cursor.getString(0)).thenReturn(names[0], names[1], names[2]).thenThrow()

--- a/app/src/androidTest/java/ch/epfl/reminday/ui/activity/PreferencesActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/ch/epfl/reminday/ui/activity/PreferencesActivityInstrumentedTest.kt
@@ -1,0 +1,42 @@
+package ch.epfl.reminday.ui.activity
+
+import android.app.Activity
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import ch.epfl.reminday.R
+import ch.epfl.reminday.util.constant.ArgumentNames.PREFERENCES_ID
+import ch.epfl.reminday.util.constant.PreferenceNames.GENERAL_PREFERENCES
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreferencesActivityInstrumentedTest {
+
+    private fun launchPreferencesActivity(
+        pref_name: String?,
+        test: (ActivityScenario<PreferencesActivity>) -> Unit
+    ) {
+        val intent = Intent(getApplicationContext(), PreferencesActivity::class.java)
+        intent.putExtra(PREFERENCES_ID, pref_name)
+
+        ActivityScenario.launch<PreferencesActivity>(intent).use(test)
+    }
+
+    @Test
+    fun directlyFinishesWhenInvalidPreferencesName(): Unit = launchPreferencesActivity(null) {
+        assertEquals(Activity.RESULT_CANCELED, it.result.resultCode)
+    }
+
+    @Test
+    fun displaysAllGeneralOptions(): Unit = launchPreferencesActivity(GENERAL_PREFERENCES) {
+        onView(withText(R.string.prefs_show_delete_confirmation_title))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.prefs_require_user_unlock_title))
+            .check(matches(isDisplayed()))
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity android:name=".ui.activity.MainActivity" />
         <activity android:name=".ui.activity.BirthdayEditActivity" />
         <activity android:name=".ui.activity.BirthdaySummaryActivity" />
+        <activity android:name=".ui.activity.PreferencesActivity" />
 
         <!-- Disable default Worker factory, we'll use our custom one -->
         <provider

--- a/app/src/main/java/ch/epfl/reminday/background/CheckBirthdaysWorker.kt
+++ b/app/src/main/java/ch/epfl/reminday/background/CheckBirthdaysWorker.kt
@@ -123,7 +123,7 @@ class CheckBirthdaysWorker(
                     todayYear - bDay.year!!.value
                 )
 
-            // Build notif and display it
+            // Build notification and display it
             val notif = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(text)

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/BirthdayEditActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/BirthdayEditActivity.kt
@@ -73,7 +73,7 @@ class BirthdayEditActivity : BackArrowActivity() {
         binding = ActivityBirthdayEditBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        birthday = intent.getParcelableExtra(BIRTHDAY)
+        birthday = intent.getParcelableExtra(BIRTHDAY, Birthday::class.java)
         mode = Mode.ALL[intent.getIntExtra(
             ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL,
             Mode.DEFAULT_ORDINAL

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/BirthdaySummaryActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/BirthdaySummaryActivity.kt
@@ -23,7 +23,6 @@ import ch.epfl.reminday.util.Extensions.showConfirmationDialogWithDoNotAskAgain
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL
 import ch.epfl.reminday.util.constant.PreferenceNames.GENERAL_PREFERENCES
-import ch.epfl.reminday.util.constant.PreferenceNames.GeneralPreferenceNames.SKIP_DELETE_CONFIRMATION
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.util.*
@@ -47,16 +46,17 @@ class BirthdaySummaryActivity : BackArrowActivity() {
 
     private lateinit var birthday: Birthday
 
-    private val editActivityLauncher = registerForActivityResult(StartActivityForResult()) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            // refresh modified data if EditActivity was exited successfully
-            result.data?.getParcelableExtra<Birthday>(BIRTHDAY)?.let {
-                intent.putExtra(BIRTHDAY, it)
-            }
+    private val editActivityLauncher =
+        registerForActivityResult(StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                // refresh modified data if EditActivity was exited successfully
+                result.data?.getParcelableExtra(BIRTHDAY, Birthday::class.java)?.let {
+                    intent.putExtra(BIRTHDAY, it)
+                }
 
-            recreate()
+                recreate()
+            }
         }
-    }
 
     val recyclerIdlingResource = CountingIdlingResource("additional_information_idling_res")
 
@@ -65,7 +65,7 @@ class BirthdaySummaryActivity : BackArrowActivity() {
         binding = ActivityBirthdaySummaryBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        birthday = intent.getParcelableExtra(BIRTHDAY)!!
+        birthday = intent.getParcelableExtra(BIRTHDAY, Birthday::class.java)!!
 
         binding.apply {
             name.text = birthday.personName
@@ -98,7 +98,7 @@ class BirthdaySummaryActivity : BackArrowActivity() {
                 R.string.are_you_sure,
                 R.string.delete_birthday_are_you_sure,
                 getSharedPreferences(GENERAL_PREFERENCES, Context.MODE_PRIVATE),
-                SKIP_DELETE_CONFIRMATION
+                getString(R.string.prefs_show_delete_confirmation)
             ) {
                 deleteAndCloseActivity()
             }
@@ -118,7 +118,7 @@ class BirthdaySummaryActivity : BackArrowActivity() {
     private fun deleteAndCloseActivity() {
         lifecycleScope.launch {
             birthdayDao.delete(birthday)
-            onBackPressed()
+            finish()
         }
     }
 }

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/MainActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/MainActivity.kt
@@ -16,6 +16,8 @@ import ch.epfl.reminday.data.birthday.BirthdayDao
 import ch.epfl.reminday.databinding.ActivityMainBinding
 import ch.epfl.reminday.util.Extensions.showConfirmationDialog
 import ch.epfl.reminday.util.constant.ArgumentNames.BIRTHDAY_EDIT_MODE_ORDINAL
+import ch.epfl.reminday.util.constant.ArgumentNames.PREFERENCES_ID
+import ch.epfl.reminday.util.constant.PreferenceNames
 import ch.epfl.reminday.viewmodel.activity.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -52,7 +54,17 @@ class MainActivity : AppCompatActivity() {
             importBirthdaysFromContacts()
             true
         }
+        R.id.options_item -> {
+            launchOptionsActivity()
+            true
+        }
         else -> super.onOptionsItemSelected(item)
+    }
+
+    private fun launchOptionsActivity() {
+        val intent = Intent(this, PreferencesActivity::class.java)
+        intent.putExtra(PREFERENCES_ID, PreferenceNames.GENERAL_PREFERENCES)
+        startActivity(intent)
     }
 
     private fun launchAddBirthdayActivity() {

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/PreferencesActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/PreferencesActivity.kt
@@ -1,0 +1,40 @@
+package ch.epfl.reminday.ui.activity
+
+import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
+import androidx.preference.PreferenceFragmentCompat
+import ch.epfl.reminday.R
+import ch.epfl.reminday.ui.activity.utils.BackArrowActivity
+import ch.epfl.reminday.ui.fragment.preferences.GeneralPreferencesFragment
+import ch.epfl.reminday.util.constant.ArgumentNames.PREFERENCES_ID
+import ch.epfl.reminday.util.constant.PreferenceNames
+
+/**
+ * Activity used to display the [PreferenceFragmentCompat] corresponding to the passed [PREFERENCES_ID].
+ */
+class PreferencesActivity : BackArrowActivity(R.layout.activity_preferences) {
+
+    private val onBackPressed = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            // TODO: show confirmation dialog if changes occurred
+            finish()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val fragment = when (intent.getStringExtra(PREFERENCES_ID)) {
+            PreferenceNames.GENERAL_PREFERENCES -> GeneralPreferencesFragment()
+            else -> null
+        }
+
+        fragment?.let {
+            supportFragmentManager.beginTransaction()
+                .add(R.id.preferences_container, fragment)
+                .commit()
+        } ?: finish()
+
+        onBackPressedDispatcher.addCallback(onBackPressed)
+    }
+}

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/StartActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/StartActivity.kt
@@ -3,9 +3,13 @@ package ch.epfl.reminday.ui.activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.lifecycleScope
+import ch.epfl.reminday.R
 import ch.epfl.reminday.databinding.ActivityStartBinding
 import ch.epfl.reminday.security.PromptUserUnlock
+import ch.epfl.reminday.util.constant.PreferenceNames
+import ch.epfl.reminday.util.constant.PreferenceNames.GENERAL_PREFERENCES
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -23,14 +27,13 @@ class StartActivity : AppCompatActivity() {
         binding = ActivityStartBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.continueButton.let { button ->
-            if (prompt.canAuthenticate()) {
-                promptUser()
-                button.setOnClickListener { promptUser() }
-            } else {
-                launchMainActivity()
-                button.setOnClickListener { launchMainActivity() }
-            }
+        val prefs = getSharedPreferences(GENERAL_PREFERENCES, MODE_PRIVATE)
+        val requireUnlock = prefs.getBoolean(getString(R.string.prefs_require_user_unlock), true)
+        if (requireUnlock && prompt.canAuthenticate()) {
+            promptUser()
+            binding.continueButton.setOnClickListener { promptUser() }
+        } else {
+            launchMainActivity()
         }
     }
 

--- a/app/src/main/java/ch/epfl/reminday/ui/activity/utils/BackArrowActivity.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/activity/utils/BackArrowActivity.kt
@@ -3,25 +3,30 @@ package ch.epfl.reminday.ui.activity.utils
 import android.os.Bundle
 import android.os.PersistableBundle
 import android.view.MenuItem
+import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
+import ch.epfl.reminday.R
 
 /**
  * An activity that shows a back arrow in the action bar.
  * It executes the same action as pressing the physical back arrow of the phone
  * (ie. it calls [onBackPressed]).
  */
-abstract class BackArrowActivity : AppCompatActivity() {
+abstract class BackArrowActivity(@LayoutRes layoutRes: Int) : AppCompatActivity(layoutRes) {
+
+    constructor() : this(0)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        supportActionBar?.setDisplayShowHomeEnabled(true)
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        init()
     }
 
     override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
         super.onCreate(savedInstanceState, persistentState)
+        init()
+    }
 
+    private fun init() {
         supportActionBar?.setDisplayShowHomeEnabled(true)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
@@ -29,7 +34,7 @@ abstract class BackArrowActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             android.R.id.home -> {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/app/src/main/java/ch/epfl/reminday/ui/fragment/preferences/GeneralPreferencesFragment.kt
+++ b/app/src/main/java/ch/epfl/reminday/ui/fragment/preferences/GeneralPreferencesFragment.kt
@@ -1,0 +1,13 @@
+package ch.epfl.reminday.ui.fragment.preferences
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import ch.epfl.reminday.R
+import ch.epfl.reminday.util.constant.PreferenceNames
+
+class GeneralPreferencesFragment : PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        preferenceManager.sharedPreferencesName = PreferenceNames.GENERAL_PREFERENCES
+        setPreferencesFromResource(R.xml.preferences_general, null)
+    }
+}

--- a/app/src/main/java/ch/epfl/reminday/util/Extensions.kt
+++ b/app/src/main/java/ch/epfl/reminday/util/Extensions.kt
@@ -48,13 +48,11 @@ object Extensions {
         @StringRes title: Int,
         @StringRes text: Int,
         preferences: SharedPreferences,
-        skipConfirmationFlag: String,
+        showConfirmationFlag: String,
         onConfirm: () -> Unit
     ) {
-        val skipConfirmation = preferences.getBoolean(skipConfirmationFlag, false)
-        if (skipConfirmation) {
-            onConfirm.invoke()
-        } else {
+        val showConfirmation = preferences.getBoolean(showConfirmationFlag, true)
+        if (showConfirmation) {
             val binding = DialogDoNotAskAgainBinding.inflate(layoutInflater)
             binding.messageTextView.text = getString(text)
 
@@ -64,12 +62,14 @@ object Extensions {
                 .setPositiveButton(R.string.confirm) { dialog, _ ->
                     dialog.dismiss()
                     preferences.edit()
-                        .putBoolean(skipConfirmationFlag, binding.checkboxDoNotAskAgain.isChecked)
-                        .commit()
+                        .putBoolean(showConfirmationFlag, !binding.checkboxDoNotAskAgain.isChecked)
+                        .apply()
                     onConfirm.invoke()
                 }.setNegativeButton(R.string.cancel) { dialog, _ ->
                     dialog.cancel()
                 }.show()
+        } else {
+            onConfirm.invoke()
         }
     }
 }

--- a/app/src/main/java/ch/epfl/reminday/util/constant/ArgumentNames.kt
+++ b/app/src/main/java/ch/epfl/reminday/util/constant/ArgumentNames.kt
@@ -2,6 +2,7 @@ package ch.epfl.reminday.util.constant
 
 import ch.epfl.reminday.data.birthday.Birthday
 import ch.epfl.reminday.ui.activity.BirthdayEditActivity
+import ch.epfl.reminday.ui.activity.PreferencesActivity
 
 object ArgumentNames {
 
@@ -15,4 +16,9 @@ object ArgumentNames {
      * Should be set to the ordinal of a value of [BirthdayEditActivity.Mode]
      */
     const val BIRTHDAY_EDIT_MODE_ORDINAL = "edit_mode"
+
+    /**
+     * The name of the preference fragment that [PreferencesActivity] should show.
+     */
+    const val PREFERENCES_ID = "preferences_id"
 }

--- a/app/src/main/java/ch/epfl/reminday/util/constant/PreferenceNames.kt
+++ b/app/src/main/java/ch/epfl/reminday/util/constant/PreferenceNames.kt
@@ -10,17 +10,9 @@ object PreferenceNames {
     // =============================================================================================
     /**
      * Name of the [SharedPreferences] that stores general app options.
+     * These preferences names are accessible via the android resources (R.string.prefs_***).
      */
     const val GENERAL_PREFERENCES = "general"
-
-    /** Preferences related to general app options go here. */
-    object GeneralPreferenceNames {
-        /**
-         * Whether future delete confirmations should be skipped.
-         * Defaults to false.
-         */
-        const val SKIP_DELETE_CONFIRMATION = "skip_delete_confirmation"
-    }
 
     // =============================================================================================
     /**

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/preferences_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/menu/menu_main_activity.xml
+++ b/app/src/main/res/menu/menu_main_activity.xml
@@ -8,4 +8,8 @@
     <item
         android:id="@+id/import_from_contacts_item"
         android:title="@string/import_from_contacts_item_text" />
+
+    <item
+        android:id="@+id/options_item"
+        android:title="@string/options_text" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="continue_">Continue</string>
+    <string name="restart_required">Need to restart the app</string>
+    <string name="do_not_ask_again">Do not ask again</string>
 
     <!-- Used in forms -->
     <string name="full_name">Name</string>
@@ -22,6 +24,7 @@
     <!-- Menu items -->
     <string name="add_birthday_item_text">Add birthday</string>
     <string name="import_from_contacts_item_text">Import from contacts</string>
+    <string name="options_text">Options</string>
     <string name="edit_birthday_item_text">Edit birthday</string>
     <string name="delete_birthday_item_text">Delete birthday</string>
 
@@ -37,11 +40,20 @@
     <string name="birthday_will_be_overwritten">A birthday for a person with the same name already exists. Are you sure you want to overwrite that entry?</string>
     <string name="import_from_contacts_no_contacts">Found no contacts to import</string>
 
-    <string name="do_not_ask_again">Do not ask again</string>
+    <string name="button_info_add_content_description">Add additional information</string>
 
+    <!-- Notifications -->
     <string name="notif_channel_title">ReminDay - Birthday</string>
     <string name="notif_title">Happy Birthday %1$s !</string>
     <string name="notif_text">"Today is the %1$s, it's %2$s's birthday."</string>
     <string name="notif_additional_text_year_known">"They are %1$d!"</string>
-    <string name="button_info_add_content_description">Add additional information</string>
+
+    <!-- Preferences ids (not translatable) -->
+    <string name="prefs_show_delete_confirmation" translatable="false">show_delete_confirmation</string>
+    <string name="prefs_require_user_unlock" translatable="false">prefs_require_user_unlock</string>
+
+    <!-- Preferences strings for display -->
+    <string name="prefs_show_delete_confirmation_title">Display confirmation dialog when deleting a birthday</string>
+    <string name="prefs_require_user_unlock_title">Require user unlock at startup</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,11 @@
     <string name="prefs_require_user_unlock" translatable="false">prefs_require_user_unlock</string>
 
     <!-- Preferences strings for display -->
-    <string name="prefs_show_delete_confirmation_title">Display confirmation dialog when deleting a birthday</string>
+    <string name="prefs_category_general">General settings</string>
     <string name="prefs_require_user_unlock_title">Require user unlock at startup</string>
+
+    <string name="prefs_category_dialogs">Dialog settings</string>
+    <string name="prefs_show_delete_confirmation_title">Delete confirmation dialog</string>
+    <string name="prefs_show_delete_confirmation_subtitle">Display confirmation dialog when deleting a birthday</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <PreferenceCategory app:title="General settings">
-        <SwitchPreferenceCompat
-            app:defaultValue="true"
-            app:key="@string/prefs_show_delete_confirmation"
-            app:persistent="true"
-            app:title="@string/prefs_show_delete_confirmation_title" />
-
+    <PreferenceCategory app:title="@string/prefs_category_general">
         <SwitchPreferenceCompat
             app:defaultValue="true"
             app:key="@string/prefs_require_user_unlock"
             app:persistent="true"
             app:title="@string/prefs_require_user_unlock_title" />
+    </PreferenceCategory>
+
+    <PreferenceCategory app:title="@string/prefs_category_dialogs">
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="@string/prefs_show_delete_confirmation"
+            app:persistent="true"
+            app:summary="@string/prefs_show_delete_confirmation_subtitle"
+            app:title="@string/prefs_show_delete_confirmation_title" />
 
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_general.xml
+++ b/app/src/main/res/xml/preferences_general.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory app:title="General settings">
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="@string/prefs_show_delete_confirmation"
+            app:persistent="true"
+            app:title="@string/prefs_show_delete_confirmation_title" />
+
+        <SwitchPreferenceCompat
+            app:defaultValue="true"
+            app:key="@string/prefs_require_user_unlock"
+            app:persistent="true"
+            app:title="@string/prefs_require_user_unlock_title" />
+
+    </PreferenceCategory>
+</PreferenceScreen>


### PR DESCRIPTION
Added PreferencesActivity & GeneralPreferenceFragment. More fragments can be added in the future.
Option screen is available from the item menu in MainActivity.

Added 2 options (for now):
- an option to toggle off/on the lock screen at app startup
- a way to toggle off/(back) on the confirmation dialogs on birthday deletion

<img src="https://user-images.githubusercontent.com/13187080/188418459-72664490-2b84-44a2-869d-9de9c4802a1f.png" width="500" />
